### PR TITLE
fix:🐟1108-気分グラフのエラー修正

### DIFF
--- a/app/helpers/moods_helper.rb
+++ b/app/helpers/moods_helper.rb
@@ -13,25 +13,20 @@ module MoodsHelper
   end
 
   # グラフ用データ + 日時情報を保持
-  def mood_chart_data(moods)
-    # グラフデータ
-    chart_data = {}
-    # 日時情報（ツールチップ用）
-    datetime_info = {}
+  def mood_data_for_recent(moods)
+    result = {}
 
-    moods.each_with_index do |mood, index|
+    moods.each do |mood|
       feeling_label = FEELING_LABELS[mood.feeling]
       next if feeling_label.nil?
 
-      label = "#{index + 1}回目"
-      datetime = mood.created_at.in_time_zone('Asia/Tokyo').strftime("%Y年%m月%d日 %H:%M")
+      # X軸ラベル: "11/07 15:30"
+      datetime_label = mood.created_at.in_time_zone('Asia/Tokyo').strftime("%m/%d %H:%M")
 
-      chart_data[feeling_label] ||= {}
-      chart_data[feeling_label][label] = 1
-
-      datetime_info[label] = datetime
+      result[feeling_label] ||= {}
+      result[feeling_label][datetime_label] = 1
     end
 
-    [chart_data, datetime_info]
+    result
   end
 end

--- a/app/views/moods/analytics.html.erb
+++ b/app/views/moods/analytics.html.erb
@@ -60,7 +60,7 @@
             </div>
         </div>
 
-        <!-- 🔧 直近30回分の気分推移 -->
+        <!-- 直近30回分の気分推移 -->
 <div class="card bg-base-100 shadow-xl">
   <div class="card-body">
     <h2 class="card-title">直近30回の気分推移</h2>
@@ -68,9 +68,7 @@
       記録回数: <%= @recent_moods.count %> / 30回
     </p>
     
-    <% chart_data, datetime_info = mood_chart_data(@recent_moods) %>
-    
-    <%= line_chart chart_data,
+    <%= line_chart mood_data_for_recent(@recent_moods),
         height: "350px",
         colors: ["#10b981", "#6b7280", "#ef4444"],
         library: {
@@ -78,33 +76,21 @@
           plugins: {
             legend: {
               labels: { color: 'hsl(var(--bc))' }
-            },
-            tooltip: {
-              callbacks: {
-                title: function(context) {
-                  var label = context[0].label;
-                  var datetimeInfo = <%= raw datetime_info.to_json %>;
-                  return datetimeInfo[label] || label;
-                },
-                label: function(context) {
-                  return context.dataset.label + ': 記録あり';
-                }
-              }
             }
           },
           scales: {
             x: { 
               title: {
                 display: true,
-                text: '記録回数',
+                text: '記録日時',
                 color: 'hsl(var(--bc))'
               },
               ticks: { 
                 color: 'hsl(var(--bc))',
-                callback: function(value, index) {
-                  // 5の倍数だけラベル表示
-                  return (index + 1) % 5 === 0 ? (index + 1) + '回目' : '';
-                }
+                maxRotation: 45,
+                minRotation: 45,
+                autoSkip: true,
+                maxTicksLimit: 10
               }
             },
             y: { 
@@ -127,7 +113,7 @@
         } %>
     
     <p class="text-xs text-base-content/50 mt-4">
-      ※ポイントにカーソルを合わせると詳細な日時が表示されます
+      ※X軸は記録した日時を表示しています
     </p>
   </div>
 </div>


### PR DESCRIPTION

- [×] 週間トレンドを削除（機能的に不要なため）
- [×] 週間7日分推移を直近30回分の折れ線グラフに
　　：1日に何回もチェックインアウトを行う場合にも対応
　　：気分を登録しなかった場合も「データがない」とならないで済む