### PR TITLE
re:🌀1118-checkin_pathの再設定

### DIFF
--- a/app/views/checkinout_records/checkin.turbo_stream.erb
+++ b/app/views/checkinout_records/checkin.turbo_stream.erb
@@ -6,7 +6,7 @@
 
             <!-- チェックアウトボタン -->
             <div class="space-y-4 py-4">
-            <%= link_to checkout_page_checkinout_records_path,
+            <%= link_to checkout_path,
                     class: "btn btn-outline btn-accent btn-lg px-16 py-4 text-2xl shadow-lg w-full block" do %>
                 チェックアウト
                 <% end %>

--- a/app/views/checkinout_records/components/_navigation.html.erb
+++ b/app/views/checkinout_records/components/_navigation.html.erb
@@ -9,7 +9,7 @@
 
         <!-- チェックイン/アウト -->
         <% if today_record %>
-        <%= link_to checkout_page_checkinout_records_path,
+        <%= link_to checkout_path,
             class: "flex flex-col items-center bg-red-500 rounded-lg shadow p-3 sm:p-4 hover:shadow-md transition-all w-20 sm:w-24" do %>
             <div class="text-2xl sm:text-3xl mb-1">👋</div>
             <span class="text-xs font-semibold text-white">終了</span>

--- a/app/views/checkinout_records/edit_today.html.erb
+++ b/app/views/checkinout_records/edit_today.html.erb
@@ -40,7 +40,7 @@
             <!-- ボタンエリア -->
             <div class="space-y-4 mb-8">
             <!-- チェックアウトボタン -->
-            <%= link_to checkout_page_checkinout_records_path,
+            <%= link_to checkout_path,
                     class: "btn btn-outline btn-accent btn-lg px-16 py-4 text-2xl shadow-lg w-full block" do %>
                 チェックアウト
                 <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -28,7 +28,7 @@
               <!-- ログイン済みの場合は常に表示 -->
               <li><%= link_to "チェックイン", checkin_path,
                             class: "menu-item flex items-center px-4 py-2" %></li>
-              <li><%= link_to "チェックアウト", checkout_page_checkinout_records_path %></li>
+              <li><%= link_to "チェックアウト", checkout_path %></li>
               <li><%= link_to "気分グラフ", analytics_moods_path %></li>
               <li><%= link_to "🌱ページ", plants_path %></li>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   # LINE誘導ページ
   get "/line_guide", to: "line_guides#show"
 
+  # 静的ページ
   root "static_pages#top"
   get "how_to_use", to: "static_pages#how_to_use"
   get "terms", to: "static_pages#terms"
@@ -28,9 +29,9 @@ Rails.application.routes.draw do
 
   resources :checkinout_records, only: [ :edit ] do
     collection do
-      get :checkin_page
+      get :checkin_page, as: :checkin
       post :checkin
-      get :checkout_page
+      get :checkout_page, as: :checkout
       patch :checkout
     end
 
@@ -41,8 +42,6 @@ Rails.application.routes.draw do
     end
   end
 
-  # My page (moved out from checkinout_records)
-  # Use a singular resource to model a single per-user page; keep the old path helper for compatibility
   resource :mypage, only: [ :show ]
   get "/checkinout_records/mypage", to: "mypage#show", as: "mypage_checkinout_records"
 


### PR DESCRIPTION
気分チェッカー、気分メモをチェックアウト前に持ってきたことで
edit_todayページ関連が全部いらなくなった。
smart_checkin、edit_todayのメソッドも削除した場合に
ルーティングでの修正も必要だったので実行。
ついでにcheckoutも同じ設計にしたシンプルにした。